### PR TITLE
added profiler scheduler on interval basis

### DIFF
--- a/server/src/main/java/module-info.java
+++ b/server/src/main/java/module-info.java
@@ -456,4 +456,5 @@ module org.elasticsearch.server {
             org.elasticsearch.serverless.shardhealth,
             org.elasticsearch.serverless.apifiltering;
     exports org.elasticsearch.lucene.spatial;
+    exports org.elasticsearch.myprofiler;
 }

--- a/server/src/main/java/org/elasticsearch/action/ActionModule.java
+++ b/server/src/main/java/org/elasticsearch/action/ActionModule.java
@@ -702,6 +702,9 @@ public class ActionModule extends AbstractModule {
         actions.register(GetAliasesAction.INSTANCE, TransportGetAliasesAction.class);
         actions.register(GetSettingsAction.INSTANCE, TransportGetSettingsAction.class);
 
+
+        actions.register(TransportStartProfilerAction.ACTION_TYPE,TransportStartProfilerAction.class);
+        actions.register(TransportStopProfilerAction.ACTION_TYPE,TransportStopProfilerAction.class);
         actions.register(TransportIndexAction.TYPE, TransportIndexAction.class);
         actions.register(TransportGetAction.TYPE, TransportGetAction.class);
         actions.register(TermVectorsAction.INSTANCE, TransportTermVectorsAction.class);

--- a/server/src/main/java/org/elasticsearch/action/TransportStartProfilerAction.java
+++ b/server/src/main/java/org/elasticsearch/action/TransportStartProfilerAction.java
@@ -1,0 +1,166 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.action;
+
+import org.elasticsearch.action.support.ActionFilters;
+import org.elasticsearch.action.support.nodes.BaseNodeResponse;
+import org.elasticsearch.action.support.nodes.BaseNodesRequest;
+import org.elasticsearch.action.support.nodes.BaseNodesResponse;
+import org.elasticsearch.action.support.nodes.TransportNodesAction;
+import org.elasticsearch.cluster.ClusterName;
+import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.node.DiscoveryNode;
+import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.util.concurrent.EsExecutors;
+import org.elasticsearch.myprofiler.ProfilerScheduler;
+import org.elasticsearch.myprofiler.ProfilerSchedulerHolder;
+import org.elasticsearch.myprofiler.ProfilerState;
+import org.elasticsearch.rest.action.ProfilerActionHandler;
+import org.elasticsearch.tasks.Task;
+import org.elasticsearch.transport.TransportService;
+
+import java.io.IOException;
+import java.util.List;
+
+public class TransportStartProfilerAction extends TransportNodesAction<
+    TransportStartProfilerAction.Request,
+    TransportStartProfilerAction.Response,
+    TransportStartProfilerAction.NodeRequest,
+    TransportStartProfilerAction.NodeResponse> {
+
+    public static final ActionType<Response> ACTION_TYPE = new ActionType<>("cluster:admin/profiler/start");
+
+    @Inject
+    public TransportStartProfilerAction(ClusterService clusterService, TransportService transportService, ActionFilters actionFilters) {
+        super("cluster:admin/profiler/start",
+            clusterService,
+            transportService,
+            actionFilters,
+
+            TransportStartProfilerAction.NodeRequest::new,
+            EsExecutors.DIRECT_EXECUTOR_SERVICE);
+    }
+
+    @Override
+    protected void resolveRequest(Request request, ClusterState clusterState) {
+        // If nodesIds are null or empty, resolve to all nodes
+        if (request.nodesIds() == null || request.nodesIds().length == 0) {
+            request.setConcreteNodes(clusterState.nodes().getNodes().values().toArray(DiscoveryNode[]::new));
+        } else {
+            super.resolveRequest(request, clusterState);
+        }
+    }
+
+    @Override
+    protected Response newResponse(Request request, List<NodeResponse> responses, List<FailedNodeException> failures) {
+        return new Response(clusterService.getClusterName(), responses, failures);
+    }
+    @Override
+    protected NodeRequest newNodeRequest(Request request) {
+        return new NodeRequest(request);
+    }
+    @Override
+    protected NodeResponse newNodeResponse(StreamInput in, DiscoveryNode node) throws IOException {
+        return new NodeResponse(in);
+    }
+
+    @Override
+    protected NodeResponse nodeOperation(NodeRequest request, Task task) {
+//        ProfilerState profilerState = ProfilerState.getInstance();
+////        if ("start".equals(request.getAction())) {
+//        profilerState.enableProfiling();
+        ProfilerScheduler profilerScheduler = ProfilerSchedulerHolder.getProfilerScheduler();
+        profilerScheduler.start();
+//        ProfilerActionHandler.profil
+//        } else {
+//            profilerState.disableProfiling();
+//        }
+        return new NodeResponse(clusterService.localNode());
+    }
+
+
+    public static class Request extends BaseNodesRequest<Request> {
+//        private String action;
+
+        public Request(StreamInput in) throws IOException {
+            super(in);
+//            this.action = in.readString();
+        }
+
+        public Request(String action,String... nodesIds) {
+            super(nodesIds);
+//            this.action = action;
+        }
+//        public String getAction() {
+//            return action;
+//        }
+
+    }
+    public static class Response extends BaseNodesResponse<NodeResponse> {
+        public Response(){
+            super(null,null,null);
+        }
+        public Response(StreamInput in) throws IOException {
+            super(in);
+        }
+
+        public Response(ClusterName clusterName, List<NodeResponse> nodeResponses, List<FailedNodeException> failures) {
+            super(clusterName, nodeResponses, failures);
+        }
+        @Override
+        protected List<NodeResponse> readNodesFrom(StreamInput in) throws IOException {
+            return in.readCollectionAsList(NodeResponse::new);
+        }
+
+        @Override
+        protected void writeNodesTo(StreamOutput out, List<NodeResponse> nodes) throws IOException {
+            out.writeCollection(nodes);
+        }
+    }
+
+    public static class NodeRequest extends BaseNodesRequest<Request> {
+//        private String action;
+        public NodeRequest(StreamInput in) throws IOException {
+            super(in);
+//            this.action = "start";
+        }
+
+        public NodeRequest(Request request) {
+            super(String.valueOf(request));
+//            this.action = request.getAction();
+        }
+//        public String getAction() {
+//            return action;
+//        }
+    }
+    public static class NodeResponse extends BaseNodeResponse {
+        public NodeResponse(StreamInput in) throws IOException {
+            super(in);
+        }
+
+        public NodeResponse(DiscoveryNode node) {
+            super(node);
+        }
+
+        @Override
+        public void writeTo(StreamOutput out) throws IOException {
+            super.writeTo(out);
+        }
+    }
+
+
+
+
+
+
+}
+

--- a/server/src/main/java/org/elasticsearch/action/TransportStopProfilerAction.java
+++ b/server/src/main/java/org/elasticsearch/action/TransportStopProfilerAction.java
@@ -1,0 +1,158 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.action;
+
+import org.elasticsearch.action.support.ActionFilters;
+import org.elasticsearch.action.support.nodes.BaseNodeResponse;
+import org.elasticsearch.action.support.nodes.BaseNodesRequest;
+import org.elasticsearch.action.support.nodes.BaseNodesResponse;
+import org.elasticsearch.action.support.nodes.TransportNodesAction;
+import org.elasticsearch.cluster.ClusterName;
+import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.node.DiscoveryNode;
+import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.util.concurrent.EsExecutors;
+import org.elasticsearch.myprofiler.ProfilerScheduler;
+import org.elasticsearch.myprofiler.ProfilerSchedulerHolder;
+import org.elasticsearch.myprofiler.ProfilerState;
+import org.elasticsearch.tasks.Task;
+import org.elasticsearch.transport.TransportService;
+
+import java.io.IOException;
+import java.util.List;
+
+public class TransportStopProfilerAction extends TransportNodesAction<
+    TransportStopProfilerAction.Request,
+    TransportStopProfilerAction.Response,
+    TransportStopProfilerAction.NodeRequest,
+    TransportStopProfilerAction.NodeResponse> {
+
+    public static final ActionType<TransportStopProfilerAction.Response> ACTION_TYPE = new ActionType<>("cluster:admin/profiler/stop");
+
+    @Inject
+    public TransportStopProfilerAction(ClusterService clusterService, TransportService transportService, ActionFilters actionFilters) {
+        super("cluster:admin/profiler/stop",
+            clusterService,
+            transportService,
+            actionFilters,
+
+            TransportStopProfilerAction.NodeRequest::new,
+            EsExecutors.DIRECT_EXECUTOR_SERVICE);
+    }
+
+    @Override
+    protected void resolveRequest(TransportStopProfilerAction.Request request, ClusterState clusterState) {
+        // If nodesIds are null or empty, resolve to all nodes
+        if (request.nodesIds() == null || request.nodesIds().length == 0) {
+            request.setConcreteNodes(clusterState.nodes().getNodes().values().toArray(DiscoveryNode[]::new));
+        } else {
+            super.resolveRequest(request, clusterState);
+        }
+    }
+
+    @Override
+    protected TransportStopProfilerAction.Response newResponse(TransportStopProfilerAction.Request request, List<TransportStopProfilerAction.NodeResponse> responses, List<FailedNodeException> failures) {
+        return new TransportStopProfilerAction.Response(clusterService.getClusterName(), responses, failures);
+    }
+    @Override
+    protected TransportStopProfilerAction.NodeRequest newNodeRequest(TransportStopProfilerAction.Request request) {
+        return new TransportStopProfilerAction.NodeRequest(request);
+    }
+    @Override
+    protected TransportStopProfilerAction.NodeResponse newNodeResponse(StreamInput in, DiscoveryNode node) throws IOException {
+        return new TransportStopProfilerAction.NodeResponse(in);
+    }
+
+    @Override
+    protected TransportStopProfilerAction.NodeResponse nodeOperation(TransportStopProfilerAction.NodeRequest request, Task task) {
+//        ProfilerState profilerState = ProfilerState.getInstance();
+////        if ("start".equals(request.getAction())) {
+////        profilerState.enableProfiling();
+////        } else {
+//        profilerState.disableProfiling();
+        ProfilerScheduler profilerScheduler = ProfilerSchedulerHolder.getProfilerScheduler();
+        profilerScheduler.stop();
+//        }
+        return new TransportStopProfilerAction.NodeResponse(clusterService.localNode());
+    }
+
+    public static class Request extends BaseNodesRequest<TransportStopProfilerAction.Request> {
+//        private String action;
+
+        public Request(StreamInput in) throws IOException {
+            super(in);
+//            this.action = in.readString();
+        }
+
+        public Request(String action,String... nodesIds) {
+            super(nodesIds);
+//            this.action = action;
+        }
+//        public String getAction() {
+//            return action;
+//        }
+
+    }
+    public static class Response extends BaseNodesResponse<TransportStopProfilerAction.NodeResponse> {
+        public Response(){
+            super(null,null,null);
+        }
+        public Response(StreamInput in) throws IOException {
+            super(in);
+        }
+
+        public Response(ClusterName clusterName, List<TransportStopProfilerAction.NodeResponse> nodeResponses, List<FailedNodeException> failures) {
+            super(clusterName, nodeResponses, failures);
+        }
+        @Override
+        protected List<TransportStopProfilerAction.NodeResponse> readNodesFrom(StreamInput in) throws IOException {
+            return in.readCollectionAsList(TransportStopProfilerAction.NodeResponse::new);
+        }
+
+        @Override
+        protected void writeNodesTo(StreamOutput out, List<TransportStopProfilerAction.NodeResponse> nodes) throws IOException {
+            out.writeCollection(nodes);
+        }
+    }
+
+    public static class NodeRequest extends BaseNodesRequest<TransportStopProfilerAction.Request> {
+        //        private String action;
+        public NodeRequest(StreamInput in) throws IOException {
+            super(in);
+//            this.action = "start";
+        }
+
+        public NodeRequest(TransportStopProfilerAction.Request request) {
+            super(String.valueOf(request));
+//            this.action = request.getAction();
+        }
+//        public String getAction() {
+//            return action;
+//        }
+    }
+    public static class NodeResponse extends BaseNodeResponse {
+        public NodeResponse(StreamInput in) throws IOException {
+            super(in);
+        }
+
+        public NodeResponse(DiscoveryNode node) {
+            super(node);
+        }
+
+        @Override
+        public void writeTo(StreamOutput out) throws IOException {
+            super.writeTo(out);
+        }
+    }
+
+
+}

--- a/server/src/main/java/org/elasticsearch/action/support/nodes/TransportNodesAction.java
+++ b/server/src/main/java/org/elasticsearch/action/support/nodes/TransportNodesAction.java
@@ -53,10 +53,12 @@ public abstract class TransportNodesAction<
     private static final Logger logger = LogManager.getLogger(TransportNodesAction.class);
 
     protected final ClusterService clusterService;
+
     protected final TransportService transportService;
     protected final String transportNodeAction;
 
     private final Executor finalExecutor;
+//    private final ProfilerScheduler profilerScheduler;
 
     /**
      * @param actionName        action name

--- a/server/src/main/java/org/elasticsearch/client/internal/node/NodeClient.java
+++ b/server/src/main/java/org/elasticsearch/client/internal/node/NodeClient.java
@@ -63,6 +63,7 @@ public class NodeClient extends AbstractClient {
         this.localNodeId = localNodeId;
         this.localConnection = localConnection;
         this.remoteClusterService = remoteClusterService;
+
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/myprofiler/ProfilerScheduler.java
+++ b/server/src/main/java/org/elasticsearch/myprofiler/ProfilerScheduler.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.myprofiler;
+
+
+import org.elasticsearch.ElasticsearchException;
+import org.elasticsearch.action.index.IndexRequest;
+import org.elasticsearch.client.internal.node.NodeClient;
+import org.elasticsearch.core.TimeValue;
+import org.elasticsearch.threadpool.Scheduler;
+import org.elasticsearch.threadpool.ThreadPool;
+import org.elasticsearch.xcontent.XContentBuilder;
+import org.elasticsearch.xcontent.XContentFactory;
+
+import java.io.IOException;
+import java.util.Map;
+
+public class ProfilerScheduler {
+    private final ThreadPool threadPool;
+    private final NodeClient client;
+    private final TimeValue interval;
+    private volatile Scheduler.Cancellable cancellable;
+
+    public ProfilerScheduler(ThreadPool threadPool, NodeClient client, TimeValue interval) {
+        this.threadPool = threadPool;
+        this.client = client;
+        this.interval = interval;
+    }
+
+    public synchronized void start() {
+        if (cancellable == null) {
+            ProfilerState.getInstance().enableProfiling();
+            cancellable = threadPool.scheduleWithFixedDelay(this::run, interval,threadPool.generic());
+        }
+    }
+    public synchronized void stop() {
+        if (cancellable != null) {
+            ProfilerState.getInstance().disableProfiling();
+            cancellable.cancel();
+            cancellable = null;
+        }
+    }
+
+    private void run() {
+        ProfilerState profilerState = ProfilerState.getInstance();
+        long startTime = System.currentTimeMillis();
+        long endTime = startTime+300000;
+        if (profilerState.isProfiling()) {
+            Map<String, Long> stats = profilerState.collectAndResetStats();
+            // Code to push stats to Elasticsearch index
+            pushStatsToIndex(stats,startTime,endTime);
+        }
+    }
+    private void pushStatsToIndex(Map<String, Long> stats,long startTime,long endTime) throws ElasticsearchException{
+
+//        System.out.println("Statistics for the last interval:");
+//        for (Map.Entry<String, Long> entry : stats.entrySet()) {
+//            System.out.println(entry.getKey() + ": " + entry.getValue());
+//        }
+        try {
+            XContentBuilder builder = XContentFactory.jsonBuilder().startObject()
+                .field("startTime", startTime)
+                .field("endTime", endTime)
+                .startArray("stats");
+
+            for (Map.Entry<String, Long> entry : stats.entrySet()) {
+                builder.startObject()
+                    .field("index", entry.getKey())
+                    .field("search_query_count", entry.getValue())
+                    .endObject();
+            }
+            builder.endArray().endObject();
+            IndexRequest indexRequest = new IndexRequest("profiler_stats").source(builder);
+            client.index(indexRequest);
+        }catch (IOException e){
+            throw new ElasticsearchException(e);
+        }
+
+    }
+
+}

--- a/server/src/main/java/org/elasticsearch/myprofiler/ProfilerSchedulerHolder.java
+++ b/server/src/main/java/org/elasticsearch/myprofiler/ProfilerSchedulerHolder.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.myprofiler;
+
+import org.elasticsearch.client.internal.node.NodeClient;
+import org.elasticsearch.core.TimeValue;
+import org.elasticsearch.threadpool.ThreadPool;
+
+public class ProfilerSchedulerHolder {
+    private static ProfilerScheduler profilerScheduler;
+
+    public static void initialize(ThreadPool threadPool, NodeClient client, TimeValue interval) {
+        if (profilerScheduler == null) {
+            profilerScheduler = new ProfilerScheduler(threadPool, client, interval);
+        }
+    }
+
+    public static ProfilerScheduler getProfilerScheduler() {
+        return profilerScheduler;
+    }
+}

--- a/server/src/main/java/org/elasticsearch/myprofiler/ProfilerState.java
+++ b/server/src/main/java/org/elasticsearch/myprofiler/ProfilerState.java
@@ -9,6 +9,7 @@
 package org.elasticsearch.myprofiler;
 
 
+import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicLong;
 
@@ -39,6 +40,10 @@ public class ProfilerState {
         this.profiling = false;
     }
 
+    public boolean isProfiling() {
+        return profiling;
+    }
+
     public void incrementQueryCount() {
         if (profiling) {
             queryCount.incrementAndGet();
@@ -58,5 +63,14 @@ public class ProfilerState {
     }
     public synchronized ConcurrentHashMap<String, AtomicLong> getIndex_query_count(){
         return index_query_count;
+    }
+
+    public ConcurrentHashMap<String, Long> collectAndResetStats() {
+        ConcurrentHashMap<String, Long> stats = new ConcurrentHashMap<>();
+        for (Map.Entry<String, AtomicLong> entry : index_query_count.entrySet()) {
+            stats.put(entry.getKey(), entry.getValue().getAndSet(0));
+        }
+//        stats.put("totalQueries", queryCount.getAndSet(0));
+        return stats;
     }
 }

--- a/server/src/main/java/org/elasticsearch/myprofiler/ProfilerState.java
+++ b/server/src/main/java/org/elasticsearch/myprofiler/ProfilerState.java
@@ -17,12 +17,16 @@ public class ProfilerState {
     private static ProfilerState instance;
     private boolean profiling;
     private AtomicLong queryCount;
-    private ConcurrentHashMap<String,AtomicLong> index_query_count;
+    private ConcurrentHashMap<String,AtomicLong> index_search_query_count;
+    private ConcurrentHashMap<String,AtomicLong> index_requests_count;
+    private ConcurrentHashMap<String,AtomicLong> index_get_requests_count;
 
     private ProfilerState() {
         this.profiling = false;
         this.queryCount = new AtomicLong(0);
-        this.index_query_count = new ConcurrentHashMap<>();
+        this.index_search_query_count = new ConcurrentHashMap<>();
+        this.index_requests_count = new ConcurrentHashMap<>();
+        this.index_get_requests_count = new ConcurrentHashMap<>();
     }
 
     public static synchronized ProfilerState getInstance() {
@@ -62,14 +66,28 @@ public class ProfilerState {
         queryCount.set(0);
     }
     public synchronized ConcurrentHashMap<String, AtomicLong> getIndex_query_count(){
-        return index_query_count;
+        return index_search_query_count;
+    }
+    public synchronized ConcurrentHashMap<String, AtomicLong> getIndex_requests_count(){
+        return index_requests_count;
+    }
+    public synchronized ConcurrentHashMap<String, AtomicLong> getIndex_get_requests_count(){
+        return index_get_requests_count;
     }
 
-    public ConcurrentHashMap<String, Long> collectAndResetStats() {
-        ConcurrentHashMap<String, Long> stats = new ConcurrentHashMap<>();
-        for (Map.Entry<String, AtomicLong> entry : index_query_count.entrySet()) {
-            stats.put(entry.getKey(), entry.getValue().getAndSet(0));
+
+    public ConcurrentHashMap<String, Map<String, Long>> collectAndResetStats() {
+        ConcurrentHashMap<String, Map<String, Long>> stats = new ConcurrentHashMap<>();
+        for (Map.Entry<String, AtomicLong> entry : index_search_query_count.entrySet()) {
+            stats.computeIfAbsent(entry.getKey(), k -> new ConcurrentHashMap<>()).put("search_query_count", entry.getValue().getAndSet(0));
         }
+        for (Map.Entry<String, AtomicLong> entry : index_requests_count.entrySet()) {
+            stats.computeIfAbsent(entry.getKey(), k -> new ConcurrentHashMap<>()).put("index_request_count", entry.getValue().getAndSet(0));
+        }
+        for (Map.Entry<String, AtomicLong> entry : index_get_requests_count.entrySet()) {
+            stats.computeIfAbsent(entry.getKey(), k -> new ConcurrentHashMap<>()).put("index_get_request_count", entry.getValue().getAndSet(0));
+        }
+        queryCount.set(0);
 //        stats.put("totalQueries", queryCount.getAndSet(0));
         return stats;
     }

--- a/server/src/main/java/org/elasticsearch/node/NodeConstruction.java
+++ b/server/src/main/java/org/elasticsearch/node/NodeConstruction.java
@@ -20,6 +20,7 @@ import org.elasticsearch.action.ActionModule;
 import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionResponse;
 import org.elasticsearch.action.ActionType;
+//import org.elasticsearch.action.TransportProfilerAction;
 import org.elasticsearch.action.admin.cluster.repositories.reservedstate.ReservedRepositoryAction;
 import org.elasticsearch.action.admin.indices.template.reservedstate.ReservedComposableIndexTemplateAction;
 import org.elasticsearch.action.datastreams.autosharding.DataStreamAutoShardingService;
@@ -28,6 +29,7 @@ import org.elasticsearch.action.search.SearchExecutionStatsCollector;
 import org.elasticsearch.action.search.SearchPhaseController;
 import org.elasticsearch.action.search.SearchTransportAPMMetrics;
 import org.elasticsearch.action.search.SearchTransportService;
+import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.TransportAction;
 import org.elasticsearch.action.update.UpdateHelper;
 import org.elasticsearch.client.internal.Client;
@@ -212,6 +214,7 @@ import java.io.UncheckedIOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Locale;
@@ -1330,7 +1333,6 @@ class NodeConstruction {
         Map<ActionType<? extends ActionResponse>, TransportAction<? extends ActionRequest, ? extends ActionResponse>> actions =
             forciblyCast(injector.getInstance(new Key<Map<ActionType, TransportAction>>() {
             }));
-
         client.initialize(
             actions,
             transportService.getTaskManager(),

--- a/server/src/main/java/org/elasticsearch/rest/RestController.java
+++ b/server/src/main/java/org/elasticsearch/rest/RestController.java
@@ -38,6 +38,7 @@ import org.elasticsearch.http.HttpRouteStats;
 import org.elasticsearch.http.HttpServerTransport;
 import org.elasticsearch.indices.breaker.CircuitBreakerService;
 import org.elasticsearch.rest.RestHandler.Route;
+import org.elasticsearch.rest.action.ProfilerActionHandler;
 import org.elasticsearch.rest.action.ProfilerCount;
 import org.elasticsearch.rest.action.ProfilerOff;
 import org.elasticsearch.rest.action.ProfilerOn;
@@ -134,6 +135,7 @@ public class RestController implements HttpServerTransport.Dispatcher {
         registerHandler(new ProfilerOn());
         registerHandler(new ProfilerCount());
         registerHandler(new ProfilerStatus());
+        registerHandler(new ProfilerActionHandler(client));
         this.apiProtections = new ServerlessApiProtections(false);
     }
 

--- a/server/src/main/java/org/elasticsearch/rest/RestController.java
+++ b/server/src/main/java/org/elasticsearch/rest/RestController.java
@@ -38,6 +38,7 @@ import org.elasticsearch.http.HttpRouteStats;
 import org.elasticsearch.http.HttpServerTransport;
 import org.elasticsearch.indices.breaker.CircuitBreakerService;
 import org.elasticsearch.rest.RestHandler.Route;
+//import org.elasticsearch.rest.action.ProfilerActionHandler;
 import org.elasticsearch.rest.action.ProfilerActionHandler;
 import org.elasticsearch.rest.action.ProfilerCount;
 import org.elasticsearch.rest.action.ProfilerOff;

--- a/server/src/main/java/org/elasticsearch/rest/action/ProfilerActionHandler.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/ProfilerActionHandler.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.rest.action;
+
+import org.elasticsearch.client.internal.node.NodeClient;
+import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.core.TimeValue;
+import org.elasticsearch.myprofiler.ProfilerScheduler;
+import org.elasticsearch.rest.BaseRestHandler;
+import org.elasticsearch.rest.RestRequest;
+import org.elasticsearch.rest.RestResponse;
+import org.elasticsearch.rest.RestStatus;
+import org.elasticsearch.threadpool.ThreadPool;
+
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+public class ProfilerActionHandler extends BaseRestHandler {
+
+    private final ProfilerScheduler profilerScheduler;
+
+    @Inject
+    public ProfilerActionHandler(NodeClient client) {
+        ThreadPool threadPool = client.threadPool();
+        this.profilerScheduler = new ProfilerScheduler(threadPool, client, new TimeValue(5, TimeUnit.MINUTES));
+    }
+
+    @Override
+    public String getName() {
+        return "profiler_action_handler";
+    }
+
+    @Override
+    public List<Route> routes() {
+        return List.of(
+            new Route(RestRequest.Method.POST,"/profiler/{action}")
+        );
+    }
+
+    @Override
+    protected RestChannelConsumer prepareRequest(RestRequest request, NodeClient client) {
+        String action = request.param("action");
+        if ("start".equals(action)) {
+            profilerScheduler.start();
+            return channel -> channel.sendResponse(new RestResponse(RestStatus.OK, "Profiler started"));
+        } else if ("stop".equals(action)) {
+            profilerScheduler.stop();
+            return channel -> channel.sendResponse(new RestResponse(RestStatus.OK, "Profiler stopped"));
+        } else {
+            return channel -> channel.sendResponse(new RestResponse(RestStatus.BAD_REQUEST, "Invalid action"));
+        }
+    }
+
+}

--- a/server/src/main/java/org/elasticsearch/rest/action/admin/indices/RestCreateIndexAction.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/admin/indices/RestCreateIndexAction.java
@@ -17,6 +17,7 @@ import org.elasticsearch.common.xcontent.LoggingDeprecationHandler;
 import org.elasticsearch.common.xcontent.XContentHelper;
 import org.elasticsearch.core.RestApiVersion;
 import org.elasticsearch.index.mapper.MapperService;
+import org.elasticsearch.myprofiler.ProfilerState;
 import org.elasticsearch.rest.BaseRestHandler;
 import org.elasticsearch.rest.RestRequest;
 import org.elasticsearch.rest.Scope;
@@ -29,6 +30,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicLong;
 
 import static java.util.Collections.singletonMap;
 import static org.elasticsearch.rest.RestRequest.Method.PUT;
@@ -55,6 +57,10 @@ public class RestCreateIndexAction extends BaseRestHandler {
     @Override
     public RestChannelConsumer prepareRequest(final RestRequest request, final NodeClient client) throws IOException {
         CreateIndexRequest createIndexRequest;
+        ProfilerState.getInstance().incrementQueryCount();
+        if(ProfilerState.getInstance().getStatus() == 1){
+            ProfilerState.getInstance().getIndex_requests_count().computeIfAbsent(request.params().get("index"),k->new AtomicLong(0)).addAndGet(1);
+        }
         if (request.getRestApiVersion() == RestApiVersion.V_7) {
             createIndexRequest = prepareRequestV7(request);
         } else {

--- a/server/src/main/java/org/elasticsearch/rest/action/document/RestGetAction.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/document/RestGetAction.java
@@ -13,6 +13,7 @@ import org.elasticsearch.client.internal.node.NodeClient;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.core.RestApiVersion;
 import org.elasticsearch.index.VersionType;
+import org.elasticsearch.myprofiler.ProfilerState;
 import org.elasticsearch.rest.BaseRestHandler;
 import org.elasticsearch.rest.RestRequest;
 import org.elasticsearch.rest.Scope;
@@ -23,6 +24,7 @@ import org.elasticsearch.search.fetch.subphase.FetchSourceContext;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicLong;
 
 import static org.elasticsearch.rest.RestRequest.Method.GET;
 import static org.elasticsearch.rest.RestRequest.Method.HEAD;
@@ -53,6 +55,10 @@ public class RestGetAction extends BaseRestHandler {
     public RestChannelConsumer prepareRequest(final RestRequest request, final NodeClient client) throws IOException {
         if (request.getRestApiVersion() == RestApiVersion.V_7) {
             request.param("type"); // consume and ignore the type
+        }
+        ProfilerState.getInstance().incrementQueryCount();
+        if(ProfilerState.getInstance().getStatus() == 1){
+            ProfilerState.getInstance().getIndex_get_requests_count().computeIfAbsent(request.params().get("index"),k->new AtomicLong(0)).addAndGet(1);
         }
 
         GetRequest getRequest = new GetRequest(request.param("index"), request.param("id"));

--- a/server/src/main/java/org/elasticsearch/rest/action/document/RestIndexAction.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/document/RestIndexAction.java
@@ -15,6 +15,7 @@ import org.elasticsearch.action.support.ActiveShardCount;
 import org.elasticsearch.client.internal.node.NodeClient;
 import org.elasticsearch.core.RestApiVersion;
 import org.elasticsearch.index.VersionType;
+import org.elasticsearch.myprofiler.ProfilerState;
 import org.elasticsearch.rest.BaseRestHandler;
 import org.elasticsearch.rest.RestRequest;
 import org.elasticsearch.rest.Scope;
@@ -25,6 +26,7 @@ import org.elasticsearch.rest.action.RestToXContentListener;
 import java.io.IOException;
 import java.util.List;
 import java.util.Locale;
+import java.util.concurrent.atomic.AtomicLong;
 
 import static org.elasticsearch.rest.RestRequest.Method.POST;
 import static org.elasticsearch.rest.RestRequest.Method.PUT;
@@ -105,6 +107,10 @@ public class RestIndexAction extends BaseRestHandler {
             assert request.params().get("id") == null : "non-null id: " + request.params().get("id");
             // default to op_type create
             request.params().putIfAbsent("op_type", "create");
+            ProfilerState.getInstance().incrementQueryCount();
+            if(ProfilerState.getInstance().getStatus() == 1){
+                ProfilerState.getInstance().getIndex_requests_count().computeIfAbsent(request.params().get("index"),k->new AtomicLong(0)).addAndGet(1);
+            }
             return super.prepareRequest(request, client);
         }
     }

--- a/server/src/main/java/org/elasticsearch/search/SearchService.java
+++ b/server/src/main/java/org/elasticsearch/search/SearchService.java
@@ -671,14 +671,12 @@ public class SearchService extends AbstractLifecycleComponent implements IndexEv
      */
     private SearchPhaseResult executeQueryPhase(ShardSearchRequest request, SearchShardTask task) throws Exception {
         ProfilerState.getInstance().incrementQueryCount();
-<<<<<<< HEAD
         if(ProfilerState.getInstance().getStatus() == 1){
             ProfilerState.getInstance().getIndex_query_count().computeIfAbsent(request.indices()[0],k->new AtomicLong(0)).addAndGet(1);
         }
 
        // ProfilerState.getInstance().getIndex_query_count().merge(request.indices()[0],1,Integer::sum);
-=======
->>>>>>> main
+
         final ReaderContext readerContext = createOrGetReaderContext(request);
         try (
             Releasable scope = tracer.withScope(task);

--- a/server/src/main/java/org/elasticsearch/transport/OutboundHandler.java
+++ b/server/src/main/java/org/elasticsearch/transport/OutboundHandler.java
@@ -240,6 +240,7 @@ final class OutboundHandler {
             channel.sendMessage(reference, new ActionListener<>() {
                 @Override
                 public void onResponse(Void v) {
+
                     statsTracker.markBytesWritten(messageSize);
                     listener.onResponse(v);
                     maybeLogSlowMessage(true);

--- a/server/src/main/java/org/elasticsearch/transport/TransportService.java
+++ b/server/src/main/java/org/elasticsearch/transport/TransportService.java
@@ -1164,6 +1164,7 @@ public class TransportService extends AbstractLifecycleComponent
     private static void validateActionName(String actionName) {
         // TODO we should makes this a hard validation and throw an exception but we need a good way to add backwards layer
         // for it. Maybe start with a deprecation layer
+//        System.out.println("my output printing :  " + actionName);
         if (isValidActionName(actionName) == false) {
             logger.warn("invalid action name [" + actionName + "] must start with one of: " + TransportService.VALID_ACTION_PREFIXES);
         }


### PR DESCRIPTION
- POST /profiler/start will start the profiler
- 5minutes is my interval time. In this time it collects stats.
- it will add to index "profiler-stats" in elastic search
- and repeats for next interval
- POST /profiler/stop will stop profiler
- added code for profiler to work on multiple nodes
- added get_request_count and index_request_count to metadata of index
